### PR TITLE
Fix ImageNet dataset preprocessing crash

### DIFF
--- a/pycls/datasets/imagenet.py
+++ b/pycls/datasets/imagenet.py
@@ -79,10 +79,10 @@ class ImageNet(torch.utils.data.Dataset):
         if self._split == 'train':
             # Scale and aspect ratio
             im = transforms.random_sized_crop(
-                image=im, size=cfg.TRAIN.IM_SIZE, area_frac=0.08
+                im=im, size=cfg.TRAIN.IM_SIZE, area_frac=0.08
             )
             # Horizontal flip
-            im = transforms.horizontal_flip(image=im, prob=0.5, order='HWC')
+            im = transforms.horizontal_flip(im=im, p=0.5, order='HWC')
         else:
             # Scale and center crop
             im = transforms.scale(cfg.TEST.IM_SIZE, im)

--- a/pycls/datasets/transforms.py
+++ b/pycls/datasets/transforms.py
@@ -26,12 +26,15 @@ def zero_pad(im, pad_size):
     return np.pad(im, pad_width, mode='constant')
 
 
-def horizontal_flip(im, p):
-    """Performs horizontal flip (CHW format)."""
+def horizontal_flip(im, p, order='CHW'):
+    """Performs horizontal flip (CHW or HWC format)."""
+    assert order in ['CHW', 'HWC']
     if np.random.uniform() < p:
-        im = im[:, :, ::-1]
+        if order == 'CHW':
+            im = im[:, :, ::-1]
+        else:
+            im = im[:, ::-1, :]
     return im
-
 
 def random_crop(im, size, pad_size=0):
     """Performs random crop (CHW format)."""


### PR DESCRIPTION
Fixes a crash in the ImageNet data preprocessing function _prepare_im in the ImageNet dataset class in pycls/datasets/imagenet.py.  Inputs to the transformation functions horizontal_flip and random_sized_crop in pycls/datasets/transforms.py were mislabelled and have been corrected. The horizontal_flip function was being passed an additional parameter order='HWC' which it didn't support.  This functionality was restored to horizontal_flip so that it can now process inputs in either channel-height-width (its original default) or height-width-channel order.  This is preferable to instead moving the horizontal_flip call in _prepare_im to after the conversion to CHW order for the following reason.  The horizontal_flip function causes the output numpy array to be non contiguous, and torch doesn't current support converting it to a torch tensor.  The transpose call to switch to CHW order makes the numpy array contiguous again.  An explicit numpy.ascontiguousarray could instead be used after horizontal_flip, but this seems like it could be slower.

Visual inspection of the ImageNet data preprocessing suggests it is properly preprocessing images.  Tested that the R-50 Cifar10 baseline trains to the expected accuracy as before, and that the R-50, 1gpu ImageNet baseline can complete a full epoch of training and evaluation, whereas before it would crash in the first iteration.