### PR TITLE
Fixed Cifar10 dataset __getitem__ transformations modifying loaded data permanently

### DIFF
--- a/pycls/datasets/cifar10.py
+++ b/pycls/datasets/cifar10.py
@@ -77,7 +77,7 @@ class Cifar10(torch.utils.data.Dataset):
         return im
 
     def __getitem__(self, index):
-        im, label = self._inputs[index, ...], self._labels[index]
+        im, label = self._inputs[index, ...].copy(), self._labels[index]
         im = self._prepare_im(im)
         return im, label
 


### PR DESCRIPTION
The CIFAR10 dataset class has been performing data augmentation in place, causing each call to ``__getitem__`` in ``pycls.pycls.datasets.cifar10.Cifar10`` to modify the loaded dataset permanently.

I believe this was going unnoticed because with the default settings the data loader spawns new processes at least once an epoch and passes a copy of the original, unmodified dataset to each.  The result is that the model trains well despite the bug.  Telling the data loader to only use a single process by setting the config parameter ``DATA_LOADER.NUM_WORKERS=0`` causes the model to fail to train after ~3 epochs.

Making a copy of the selected data in ``__getitem__`` fixes the problem. Sequential calls to ``__getitem__`` with the same index now return the same result, and the model trains successfully even with ``DATA_LOADER.NUM_WORKERS=0``.