### PR TITLE
Fast/simple complexity counts (flops/params/acts)

### DIFF
--- a/pycls/models/regnet.py
+++ b/pycls/models/regnet.py
@@ -85,3 +85,9 @@ class RegNet(AnyNet):
     def __init__(self):
         kwargs = RegNet.get_args()
         super(RegNet, self).__init__(**kwargs)
+
+    @staticmethod
+    def complexity(cx, **kwargs):
+        """Computes model complexity. If you alter the model, make sure to update."""
+        kwargs = RegNet.get_args() if not kwargs else kwargs
+        return AnyNet.complexity(cx, **kwargs)


### PR DESCRIPTION
Two benefit over generic complexity  version in metrics.py:
+ doesn't require initializing model (1000x speedup)
+ more general / robust solution
The only drawback is:
- More lines of code