### PR TITLE
fix nu.complexity minor error when NUM_GPUS>1

### DIFF
--- a/pycls/core/net.py
+++ b/pycls/core/net.py
@@ -106,6 +106,8 @@ def complexity_maxpool2d(cx, k, stride, padding):
 def complexity(model):
     """Compute model complexity (model can be model instance or model class)."""
     cx = complexity_init(cfg.TRAIN.IM_SIZE, cfg.TRAIN.IM_SIZE)
+    if cfg.NUM_GPUS > 1:
+        model = model.module
     cx = model.complexity(cx)
     return {"flops": cx["flops"], "params": cx["params"], "acts": cx["acts"]}
 


### PR DESCRIPTION
fix  `AttributeError: 'DistributedDataParallel' object has no attribute 'complexity'` when `cfg.NUM_GPUS > 1`