### PR TITLE
Add tag back to dump_json_stats()

### DIFF
--- a/pycls/core/logging.py
+++ b/pycls/core/logging.py
@@ -70,7 +70,8 @@ def dump_json_stats(stats):
         for k, v in stats.items()
     }
     json_stats = simplejson.dumps(stats, sort_keys=True, use_decimal=True)
-    return json_stats
+    # Tag json stats and return
+    return "{:s}{:s}".format(_TAG, json_stats)
 
 
 def load_json_stats(log_file):


### PR DESCRIPTION
Lines are no longer being tagged in dump_json_stats(). We use a tag (currently "json_stats: ") to identify which of the lines in our logs are actually jsons. It's used by load_json_stats() to look for and return json lines -- if there are no tagged lines load_json_stats() will return an empty list. 
This change modifies dump_json_stats() so that it still tags every json line (similar to what we did previously). 