### PR TITLE
Updating timing code (now always enabled)

### DIFF
--- a/pycls/core/config.py
+++ b/pycls/core/config.py
@@ -320,12 +320,6 @@ _C.CUDNN.BENCHMARK = True
 # ------------------------------------------------------------------------------------ #
 _C.PREC_TIME = CfgNode()
 
-# Perform precise timing at the start of training
-_C.PREC_TIME.ENABLED = False
-
-# Total mini-batch size
-_C.PREC_TIME.BATCH_SIZE = 128
-
 # Number of iterations to warm up the caches
 _C.PREC_TIME.WARMUP_ITER = 3
 
@@ -367,6 +361,14 @@ _C.PORT = 10001
 _C.DOWNLOAD_CACHE = "/tmp/pycls-download-cache"
 
 
+# ------------------------------------------------------------------------------------ #
+# Deprecated keys
+# ------------------------------------------------------------------------------------ #
+
+_C.register_deprecated_key("PREC_TIME.BATCH_SIZE")
+_C.register_deprecated_key("PREC_TIME.ENABLED")
+
+
 def assert_and_infer_cfg(cache_urls=True):
     """Checks config values invariants."""
     err_str = "The first lr step must start at 0"
@@ -382,8 +384,6 @@ def assert_and_infer_cfg(cache_urls=True):
     assert not _C.BN.USE_PRECISE_STATS or _C.NUM_GPUS == 1, err_str
     err_str = "Log destination '{}' not supported"
     assert _C.LOG_DEST in ["stdout", "file"], err_str.format(_C.LOG_DEST)
-    err_str = "Precise iter time computation not verified for > 1 GPU"
-    assert not _C.PREC_TIME.ENABLED or _C.NUM_GPUS == 1, err_str
     if cache_urls:
         cache_cfg_urls()
 

--- a/pycls/core/timer.py
+++ b/pycls/core/timer.py
@@ -22,8 +22,7 @@ class Timer(object):
         self.reset()
 
     def tic(self):
-        # using time.time instead of time.clock because time time.clock
-        # does not normalize for multithreading
+        # using time.time as time.clock does not normalize for multithreading
         self.start_time = time.time()
 
     def toc(self):

--- a/pycls/core/trainer.py
+++ b/pycls/core/trainer.py
@@ -152,11 +152,10 @@ def train_model():
         checkpoint.load_checkpoint(cfg.TRAIN.WEIGHTS, model)
         logger.info("Loaded initial weights from: {}".format(cfg.TRAIN.WEIGHTS))
     # Compute precise time
-    if start_epoch == 0 and cfg.PREC_TIME.ENABLED:
+    if start_epoch == 0 and cfg.PREC_TIME.NUM_ITER > 0:
         logger.info("Computing precise time...")
-        prec_time = net.compute_precise_time(model, loss_fun)
+        prec_time = net.compute_time_full(model, loss_fun)
         logger.info(logging.dump_json_stats(prec_time))
-        net.reset_bn_stats(model)
     # Create data loaders and meters
     train_loader = loader.construct_train_loader()
     test_loader = loader.construct_test_loader()
@@ -198,7 +197,6 @@ def test_model():
 
 def time_model():
     """Times a model."""
-    assert cfg.PREC_TIME.ENABLED, "PREC_TIME.ENABLED must be set."
     # Setup training/testing environment
     setup_env()
     # Construct the model and loss_fun
@@ -206,6 +204,5 @@ def time_model():
     loss_fun = builders.build_loss_fun().cuda()
     # Compute precise time
     logger.info("Computing precise time...")
-    prec_time = net.compute_precise_time(model, loss_fun)
+    prec_time = net.compute_time_full(model, loss_fun)
     logger.info(logging.dump_json_stats(prec_time))
-    net.reset_bn_stats(model)


### PR DESCRIPTION
The main change is that precise timing now uses the batch sizes actually used for training and testing. This means precise timing measures the exact setup used in training / testing as opposed to having its own batch size specified. Additionally, The timing code has now been test on 
multi-gpu (previously it was only enabled in 1 GPU setup). Old config options for precise timing have been removed.

-net.py: refactor timing code, test multi-gpu
-config.py: removed obsolete config options
-trainer.py: using new timing code + necessary tweaks
-meters.py, timer.py: minor cleanup just because