### PR TITLE
Make logging more generic

### DIFF
--- a/pycls/core/benchmark.py
+++ b/pycls/core/benchmark.py
@@ -102,24 +102,22 @@ def compute_time_full(model, loss_fun, train_loader, test_loader):
     train_loader_time = compute_time_loader(train_loader)
     # Output iter timing
     iter_times = {
-        "_type": "iter_time",
         "test_fw_time": test_fw_time,
         "train_fw_time": train_fw_time,
         "train_bw_time": train_bw_time,
         "train_fw_bw_time": train_fw_bw_time,
         "train_loader_time": train_loader_time,
     }
-    logger.info(logging.dump_json_stats(iter_times))
+    logger.info(logging.dump_log_data(iter_times, "iter_times"))
     # Output epoch timing
     epoch_times = {
-        "_type": "epoch_time",
         "test_fw_time": test_fw_time * len(test_loader),
         "train_fw_time": train_fw_time * len(train_loader),
         "train_bw_time": train_bw_time * len(train_loader),
         "train_fw_bw_time": train_fw_bw_time * len(train_loader),
         "train_loader_time": train_loader_time * len(train_loader),
     }
-    logger.info(logging.dump_json_stats(epoch_times))
+    logger.info(logging.dump_log_data(epoch_times, "epoch_times"))
     # Compute data loader overhead (assuming DATA_LOADER.NUM_WORKERS>1)
     overhead = max(0, train_loader_time - train_fw_bw_time) / train_fw_bw_time
     logger.info("Overhead of data loader is {:.2f}%".format(overhead * 100))

--- a/pycls/core/logging.py
+++ b/pycls/core/logging.py
@@ -24,8 +24,11 @@ _FORMAT = "[%(filename)s: %(lineno)3d]: %(message)s"
 # Log file name (for cfg.LOG_DEST = 'file')
 _LOG_FILE = "stdout.log"
 
-# Printed json stats lines will be tagged w/ this
+# Data output with dump_log_data(data, data_type) will be tagged w/ this
 _TAG = "json_stats: "
+
+# Data output with dump_log_data(data, data_type) will have data[_TYPE]=data_type
+_TYPE = "_type"
 
 
 def _suppress_print():
@@ -62,33 +65,22 @@ def get_logger(name):
     return logging.getLogger(name)
 
 
-def dump_json_stats(stats):
-    """Logs json stats."""
-    # Decimal + string workaround for having fixed len float vals in logs
-    stats = {
-        k: decimal.Decimal("{:.6f}".format(v)) if isinstance(v, float) else v
-        for k, v in stats.items()
-    }
-    json_stats = simplejson.dumps(stats, sort_keys=True, use_decimal=True)
-    # Tag json stats and return
-    return "{:s}{:s}".format(_TAG, json_stats)
+def dump_log_data(data, data_type, prec=4):
+    """Covert data (a dictionary) into tagged json string for logging."""
+    data[_TYPE] = data_type
+    data = float_to_decimal(data, prec)
+    data_json = simplejson.dumps(data, sort_keys=True, use_decimal=True)
+    return "{:s}{:s}".format(_TAG, data_json)
 
 
-def load_json_stats(log_file):
-    """Loads json_stats from a single log file."""
-    with open(log_file, "r") as f:
-        lines = f.readlines()
-    json_lines = [l[l.find(_TAG) + len(_TAG) :] for l in lines if _TAG in l]
-    json_stats = [simplejson.loads(l) for l in json_lines]
-    return json_stats
-
-
-def parse_json_stats(log, row_type, key):
-    """Extract values corresponding to row_type/key out of log."""
-    vals = [row[key] for row in log if row["_type"] == row_type and key in row]
-    if key == "iter" or key == "epoch":
-        vals = [int(val.split("/")[0]) for val in vals]
-    return vals
+def float_to_decimal(data, prec=4):
+    """Convert floats to decimals which allows for fixed width json."""
+    if isinstance(data, dict):
+        return {k: float_to_decimal(v, prec) for k, v in data.items()}
+    if isinstance(data, float):
+        return decimal.Decimal(("{:." + str(prec) + "f}").format(data))
+    else:
+        return data
 
 
 def get_log_files(log_dir, name_filter=""):
@@ -98,3 +90,44 @@ def get_log_files(log_dir, name_filter=""):
     f_n_ps = [(f, n) for (f, n) in zip(files, names) if os.path.exists(f)]
     files, names = zip(*f_n_ps)
     return files, names
+
+
+def load_log_data(log_file, data_types_to_skip=()):
+    """Loads log data into a dictionary of the form data[data_type][metric][index]."""
+    # Load log_file
+    assert os.path.exists(log_file), "Log file not found: {}".format(log_file)
+    with open(log_file, "r") as f:
+        lines = f.readlines()
+    # Extract and parse lines that start with _TAG and have a type specified
+    lines = [l[l.find(_TAG) + len(_TAG) :] for l in lines if _TAG in l]
+    lines = [simplejson.loads(l) for l in lines]
+    lines = [l for l in lines if _TYPE in l and not l[_TYPE] in data_types_to_skip]
+    # Generate data structure accessed by data[data_type][index][metric]
+    data_types = [l[_TYPE] for l in lines]
+    data = {t: [] for t in data_types}
+    for t, line in zip(data_types, lines):
+        del line[_TYPE]
+        data[t].append(line)
+    # Generate data structure accessed by data[data_type][metric][index]
+    for t in data:
+        metrics = sorted(data[t][0].keys())
+        err_str = "Inconsistent metrics in log for _type={}: {}".format(t, metrics)
+        assert all(sorted(d.keys()) == metrics for d in data[t]), err_str
+        data[t] = {m: [d[m] for d in data[t]] for m in metrics}
+    return data
+
+
+def sort_log_data(data):
+    """Sort each data[data_type][metric] by epoch or keep only first instance."""
+    for t in data:
+        if "epoch" not in data[t]:
+            data[t] = {m: d[0] for m, d in data[t].items()}
+            continue
+        epoch = [float(e.split("/")[0]) for e in data[t]["epoch"]]
+        if "iter" in data[t]:
+            i_cur = [float(i.split("/")[0]) for i in data[t]["iter"]]
+            i_max = [float(i.split("/")[1]) for i in data[t]["iter"]]
+            epoch = [e + (ic - 1.0) / im for e, ic, im in zip(epoch, i_cur, i_max)]
+        for m in data[t]:
+            data[t][m] = [v for _, v in sorted(zip(epoch, data[t][m]))]
+    return data

--- a/pycls/core/meters.py
+++ b/pycls/core/meters.py
@@ -133,7 +133,6 @@ class TrainMeter(object):
         eta_sec = self.iter_timer.average_time * (self.max_iter - cur_iter_total)
         mem_usage = gpu_mem_usage()
         stats = {
-            "_type": "train_iter",
             "epoch": "{}/{}".format(cur_epoch + 1, cfg.OPTIM.MAX_EPOCH),
             "iter": "{}/{}".format(cur_iter + 1, self.epoch_iters),
             "time_avg": self.iter_timer.average_time,
@@ -151,7 +150,7 @@ class TrainMeter(object):
         if (cur_iter + 1) % cfg.LOG_PERIOD != 0:
             return
         stats = self.get_iter_stats(cur_epoch, cur_iter)
-        logger.info(logging.dump_json_stats(stats))
+        logger.info(logging.dump_log_data(stats, "train_iter"))
 
     def get_epoch_stats(self, cur_epoch):
         cur_iter_total = (cur_epoch + 1) * self.epoch_iters
@@ -161,7 +160,6 @@ class TrainMeter(object):
         top5_err = self.num_top5_mis / self.num_samples
         avg_loss = self.loss_total / self.num_samples
         stats = {
-            "_type": "train_epoch",
             "epoch": "{}/{}".format(cur_epoch + 1, cfg.OPTIM.MAX_EPOCH),
             "time_avg": self.iter_timer.average_time,
             "eta": time_string(eta_sec),
@@ -175,7 +173,7 @@ class TrainMeter(object):
 
     def log_epoch_stats(self, cur_epoch):
         stats = self.get_epoch_stats(cur_epoch)
-        logger.info(logging.dump_json_stats(stats))
+        logger.info(logging.dump_log_data(stats, "train_epoch"))
 
 
 class TestMeter(object):
@@ -222,7 +220,6 @@ class TestMeter(object):
     def get_iter_stats(self, cur_epoch, cur_iter):
         mem_usage = gpu_mem_usage()
         iter_stats = {
-            "_type": "test_iter",
             "epoch": "{}/{}".format(cur_epoch + 1, cfg.OPTIM.MAX_EPOCH),
             "iter": "{}/{}".format(cur_iter + 1, self.max_iter),
             "time_avg": self.iter_timer.average_time,
@@ -237,7 +234,7 @@ class TestMeter(object):
         if (cur_iter + 1) % cfg.LOG_PERIOD != 0:
             return
         stats = self.get_iter_stats(cur_epoch, cur_iter)
-        logger.info(logging.dump_json_stats(stats))
+        logger.info(logging.dump_log_data(stats, "test_iter"))
 
     def get_epoch_stats(self, cur_epoch):
         top1_err = self.num_top1_mis / self.num_samples
@@ -246,7 +243,6 @@ class TestMeter(object):
         self.min_top5_err = min(self.min_top5_err, top5_err)
         mem_usage = gpu_mem_usage()
         stats = {
-            "_type": "test_epoch",
             "epoch": "{}/{}".format(cur_epoch + 1, cfg.OPTIM.MAX_EPOCH),
             "time_avg": self.iter_timer.average_time,
             "top1_err": top1_err,
@@ -259,4 +255,4 @@ class TestMeter(object):
 
     def log_epoch_stats(self, cur_epoch):
         stats = self.get_epoch_stats(cur_epoch)
-        logger.info(logging.dump_json_stats(stats))
+        logger.info(logging.dump_log_data(stats, "test_epoch"))

--- a/pycls/core/net.py
+++ b/pycls/core/net.py
@@ -13,7 +13,6 @@ import math
 import torch
 import torch.nn as nn
 from pycls.core.config import cfg
-from pycls.core.timer import Timer
 
 
 def init_weights(m):

--- a/pycls/core/trainer.py
+++ b/pycls/core/trainer.py
@@ -36,8 +36,9 @@ def setup_env():
         config.dump_cfg()
     # Setup logging
     logging.setup_logging()
-    # Log the config
+    # Log the config as both human readable and as a json
     logger.info("Config:\n{}".format(cfg))
+    logger.info(logging.dump_log_data(cfg, "cfg"))
     # Fix the RNG seeds (see RNG comment in core/config.py for discussion)
     np.random.seed(cfg.RNG_SEED)
     torch.manual_seed(cfg.RNG_SEED)
@@ -51,7 +52,7 @@ def setup_model():
     model = builders.build_model()
     logger.info("Model:\n{}".format(model))
     # Log model complexity
-    logger.info(logging.dump_json_stats(net.complexity(model)))
+    logger.info(logging.dump_log_data(net.complexity(model), "complexity"))
     # Transfer the model to the current GPU device
     err_str = "Cannot use more GPU devices than available"
     assert cfg.NUM_GPUS <= torch.cuda.device_count(), err_str


### PR DESCRIPTION
This commit updates logging.py to make it more generic: 
- dump_json_stats(stats) -> dump_log_data(data, data_type, prec=4): data_type is now a required argument that specifies the type of data being logged. Examples: "train_iter", "train_epoch", etc. 
- load_json_stats(log_file) -> load_log_data(log_file, data_types_to_skip=()): Loads log data into a dictionary of the form data[data_type][metric][index].
- sort_log_data(data): Sort each data[data_type][metric] by epoch or keep only first instance.
- Removed parse_json_stats(log, row_type, key) as load_log_data() and sort_log_data() is sufficient to get data for a specific data_type and metric. 
