### PR TITLE
Fix logging.get_log_files() for no logs scenario

### DIFF
--- a/pycls/core/logging.py
+++ b/pycls/core/logging.py
@@ -88,7 +88,7 @@ def get_log_files(log_dir, name_filter=""):
     names = [n for n in sorted(os.listdir(log_dir)) if name_filter in n]
     files = [os.path.join(log_dir, n, _LOG_FILE) for n in names]
     f_n_ps = [(f, n) for (f, n) in zip(files, names) if os.path.exists(f)]
-    files, names = zip(*f_n_ps)
+    files, names = zip(*f_n_ps) if len(f_n_ps) else ([], [])
     return files, names
 
 


### PR DESCRIPTION
logging.get_log_files() could throw an exception if no logs are found within log_dir (due to f_n_ps being an empty list and unpacking f_n_ps as a tuple). This is now fixed this by adding a check on the length of f_n_ps. 