### PR TITLE
fix compatibility issues w latest packets

### DIFF
--- a/pycls/core/distributed.py
+++ b/pycls/core/distributed.py
@@ -18,6 +18,10 @@ import torch
 from pycls.core.config import cfg
 
 
+# Make work w recent PyTorch versions (https://github.com/pytorch/pytorch/issues/37377)
+os.environ["MKL_THREADING_LAYER"] = "GNU"
+
+
 def is_master_proc():
     """Determines if the current process is the master process.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ isort==4.3.21
 flake8
 matplotlib
 numpy
-opencv-python
+opencv-python==4.2.0.34
 parameterized
 setuptools
 simplejson


### PR DESCRIPTION
(1) Revert to opencv-python==4.2.0.34. For some reason, with newer
opencv version we saw a 10x slowdown in the distributed data loading

(2) Added hack to distributed.py to address this issue w MKL:
https://github.com/pytorch/pytorch/issues/37377

Note: better solutions for these bugs are probably needed...