### PR TITLE
updates for pytorch_nightly, use new faster SiLU

### DIFF
--- a/MODEL_ZOO.md
+++ b/MODEL_ZOO.md
@@ -530,8 +530,8 @@ For 8 GPU training, we apply 5 epoch gradual warmup, following the [ImageNet in 
 <td align="center">5.3</td>
 <td align="center">6.7</td>
 <td align="center">256</td>
-<td align="center">34</td>
-<td align="center">9.7</td>
+<td align="center">31</td>
+<td align="center">8.8</td>
 <td align="center">24.9</td>
 <td align="center">161305613</td>
 <td align="center"><a href="https://dl.fbaipublicfiles.com/pycls/dds_baselines/161305613/EN-B0_dds_8gpu.pyth">model</a></td>
@@ -543,8 +543,8 @@ For 8 GPU training, we apply 5 epoch gradual warmup, following the [ImageNet in 
 <td align="center">7.8</td>
 <td align="center">10.9</td>
 <td align="center">256</td>
-<td align="center">55</td>
-<td align="center">15.6</td>
+<td align="center">47</td>
+<td align="center">13.2</td>
 <td align="center">24.1</td>
 <td align="center">161304979</td>
 <td align="center"><a href="https://dl.fbaipublicfiles.com/pycls/dds_baselines/161304979/EN-B1_dds_8gpu.pyth">model</a></td>
@@ -556,8 +556,8 @@ For 8 GPU training, we apply 5 epoch gradual warmup, following the [ImageNet in 
 <td align="center">9.1</td>
 <td align="center">13.8</td>
 <td align="center">256</td>
-<td align="center">70</td>
-<td align="center">19.8</td>
+<td align="center">58</td>
+<td align="center">16.4</td>
 <td align="center">23.5</td>
 <td align="center">161305015</td>
 <td align="center"><a href="https://dl.fbaipublicfiles.com/pycls/dds_baselines/161305015/EN-B2_dds_8gpu.pyth">model</a></td>
@@ -569,8 +569,8 @@ For 8 GPU training, we apply 5 epoch gradual warmup, following the [ImageNet in 
 <td align="center">12.2</td>
 <td align="center">23.8</td>
 <td align="center">256</td>
-<td align="center">113</td>
-<td align="center">32.1</td>
+<td align="center">92</td>
+<td align="center">26.4</td>
 <td align="center">22.5</td>
 <td align="center">161305060</td>
 <td align="center"><a href="https://dl.fbaipublicfiles.com/pycls/dds_baselines/161305060/EN-B3_dds_8gpu.pyth">model</a></td>
@@ -582,8 +582,8 @@ For 8 GPU training, we apply 5 epoch gradual warmup, following the [ImageNet in 
 <td align="center">19.3</td>
 <td align="center">49.5</td>
 <td align="center">128</td>
-<td align="center">243</td>
-<td align="center">69.1</td>
+<td align="center">201</td>
+<td align="center">57.1</td>
 <td align="center">21.4</td>
 <td align="center">161305098</td>
 <td align="center"><a href="https://dl.fbaipublicfiles.com/pycls/dds_baselines/161305098/EN-B4_dds_8gpu.pyth">model</a></td>
@@ -595,8 +595,8 @@ For 8 GPU training, we apply 5 epoch gradual warmup, following the [ImageNet in 
 <td align="center">30.4</td>
 <td align="center">98.9</td>
 <td align="center">64</td>
-<td align="center">527</td>
-<td align="center">146.4</td>
+<td align="center">446</td>
+<td align="center">122.6</td>
 <td align="center">21.7</td>
 <td align="center">161305138</td>
 <td align="center"><a href="https://dl.fbaipublicfiles.com/pycls/dds_baselines/161305138/EN-B5_dds_8gpu.pyth">model</a></td>

--- a/dev/model_timing.json
+++ b/dev/model_timing.json
@@ -1,39 +1,39 @@
 {
     "EfficientNet-B0": {
-        "test_fw_time": 0.0132,
-        "train_bw_time": 0.0507,
-        "train_fw_bw_time": 0.0698,
-        "train_fw_time": 0.0191
+        "test_fw_time": 0.0121,
+        "train_bw_time": 0.0442,
+        "train_fw_bw_time": 0.0633,
+        "train_fw_time": 0.0192
     },
     "EfficientNet-B1": {
-        "test_fw_time": 0.0214,
-        "train_bw_time": 0.081,
-        "train_fw_bw_time": 0.1121,
-        "train_fw_time": 0.0311
+        "test_fw_time": 0.0183,
+        "train_bw_time": 0.0678,
+        "train_fw_bw_time": 0.0952,
+        "train_fw_time": 0.0274
     },
     "EfficientNet-B2": {
-        "test_fw_time": 0.0272,
-        "train_bw_time": 0.1027,
-        "train_fw_bw_time": 0.1421,
-        "train_fw_time": 0.0394
+        "test_fw_time": 0.0226,
+        "train_bw_time": 0.0833,
+        "train_fw_bw_time": 0.1178,
+        "train_fw_time": 0.0345
     },
     "EfficientNet-B3": {
-        "test_fw_time": 0.0442,
-        "train_bw_time": 0.1669,
-        "train_fw_bw_time": 0.2308,
-        "train_fw_time": 0.0639
+        "test_fw_time": 0.0361,
+        "train_bw_time": 0.136,
+        "train_fw_bw_time": 0.19,
+        "train_fw_time": 0.054
     },
     "EfficientNet-B4": {
-        "test_fw_time": 0.0494,
-        "train_bw_time": 0.1798,
-        "train_fw_bw_time": 0.2487,
-        "train_fw_time": 0.0688
+        "test_fw_time": 0.0409,
+        "train_bw_time": 0.1473,
+        "train_fw_bw_time": 0.2053,
+        "train_fw_time": 0.058
     },
     "EfficientNet-B5": {
-        "test_fw_time": 0.0494,
-        "train_bw_time": 0.1892,
-        "train_fw_bw_time": 0.2633,
-        "train_fw_time": 0.074
+        "test_fw_time": 0.0418,
+        "train_bw_time": 0.1559,
+        "train_fw_bw_time": 0.2204,
+        "train_fw_time": 0.0645
     },
     "RegNetX-1.6GF": {
         "test_fw_time": 0.0543,
@@ -215,5 +215,5 @@
         "train_fw_bw_time": 0.1066,
         "train_fw_time": 0.0325
     },
-    "date-created": "2020-09-04 09:25:13.216404"
+    "date-created": "2020-09-28 13:59:58.235577"
 }

--- a/dev/test_models.py
+++ b/dev/test_models.py
@@ -156,8 +156,8 @@ class TestTiming(unittest.TestCase):
         print("expected = {}".format(out_expected))
         print("measured = {}".format(out))
         for k in out.keys():
-            self.assertLessEqual(out[k] / out_expected[k], 1.05)
-            self.assertLessEqual(out_expected[k] / out[k], 1.05)
+            self.assertLessEqual(out[k] / out_expected[k], 1.10)
+            self.assertLessEqual(out_expected[k] / out[k], 1.10)
 
 
 if __name__ == "__main__":

--- a/pycls/core/meters.py
+++ b/pycls/core/meters.py
@@ -42,7 +42,7 @@ def topk_errors(preds, labels, ks):
     # (i, j) = 1 if top i-th prediction for the j-th sample is correct
     top_max_k_correct = top_max_k_inds.eq(rep_max_k_labels)
     # Compute the number of topk correct predictions for each k
-    topks_correct = [top_max_k_correct[:k, :].view(-1).float().sum() for k in ks]
+    topks_correct = [top_max_k_correct[:k, :].reshape(-1).float().sum() for k in ks]
     return [(1.0 - x / preds.size(0)) * 100.0 for x in topks_correct]
 
 

--- a/pycls/models/blocks.py
+++ b/pycls/models/blocks.py
@@ -51,7 +51,10 @@ def activation():
     if activation_fun == "relu":
         return nn.ReLU(inplace=cfg.MODEL.ACTIVATION_INPLACE)
     elif activation_fun == "silu" or activation_fun == "swish":
-        return SiLU()
+        try:
+            return torch.nn.SiLU()
+        except AttributeError:
+            return SiLU()
     else:
         raise AssertionError("Unknown MODEL.ACTIVATION_FUN: " + activation_fun)
 


### PR DESCRIPTION
-meters.py: replaced view() w reshape(), was causing issue in nightly
-blocks.py: use pytorch's (faster) SiLU if available (part of nightly)
-model_timing.json/MODEL_ZOO.md: updated effnet timings with faster SiLU
-test_models.py: more buffer for timing tests due to timing variability