### PR TITLE
refactor transforms.py, added autoaug and randaug

### DIFF
--- a/pycls/core/config.py
+++ b/pycls/core/config.py
@@ -248,6 +248,12 @@ _C.TRAIN.AUTO_RESUME = True
 # Weights to start training from
 _C.TRAIN.WEIGHTS = ""
 
+# Standard deviation for AlexNet-style PCA jitter (0 gives no PCA jitter)
+_C.TRAIN.PCA_STD = 0.1
+
+# Data augmentation to use ("", "AutoAugment", "RandAugment_N2_M0.5", etc.)
+_C.TRAIN.AUGMENT = ""
+
 
 # --------------------------------- Testing options ---------------------------------- #
 _C.TEST = CfgNode()

--- a/pycls/datasets/augment.py
+++ b/pycls/datasets/augment.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Lightweight and simple implementation of AutoAugment and RandAugment.
+
+AutoAugment - https://arxiv.org/abs/1805.09501
+RandAugment - https://arxiv.org/abs/1909.13719
+
+http://github.com/tensorflow/tpu/blob/master/models/official/efficientnet/autoaugment.py
+Note that the official implementation varies substantially from the papers :-(
+
+Our AutoAugment policy should be fairly identical to the official AutoAugment policy.
+The main difference is we set POSTERIZE_MIN = 1, which avoids degenerate (all 0) images.
+Our RandAugment policy differs, and uses transforms that increase in intensity with
+increasing magnitude. This allows for a more natural control of the magnitude. That is,
+setting magnitude = 0 results in ops that leaves the image unchanged, if possible.
+We also set the range of the magnitude to be 0 to 1 to avoid setting a "max level".
+
+Our implementation is inspired by and uses policies that are the similar to those in:
+https://github.com/rwightman/pytorch-image-models/blob/master/timm/data/auto_augment.py
+Specifically our implementation can be *numerically identical* as the implementation in
+timm if using timm's "v0" policy for AutoAugment and "inc" transforms for RandAugment
+and if we set POSTERIZE_MIN = 0 (although as noted our default is POSTERIZE_MIN = 1).
+Note that magnitude in our code ranges from 0 to 1 (compared to 0 to 10 in timm).
+
+Specifically, given the same seeds, the functions from timm:
+    out_auto = auto_augment_transform("v0", {"interpolation": 2})(im)
+    out_rand = rand_augment_transform("rand-inc1-n2-m05", {"interpolation": 2})(im)
+Are numerically equivalent to:
+    POSTERIZE_MIN = 0
+    out_auto = auto_augment(im)
+    out_rand = rand_augment(im, prob=0.5, n_ops=2, magnitude=0.5)
+Tested as of 10/07/2020. Can alter corresponding params for both and should match.
+
+Finally, the ops and augmentations can be visualized as follows:
+    from PIL import Image
+    import pycls.datasets.augment as augment
+    im = Image.open("scratch.jpg")
+    im_ops = augment.visualize_ops(im)
+    im_rand = augment.visualize_aug(im, augment=augment.rand_augment, magnitude=0.5)
+    im_auto = augment.visualize_aug(im, augment=augment.auto_augment)
+    im_ops.show()
+    im_auto.show()
+    im_rand.show()
+"""
+
+import random
+
+import numpy as np
+from PIL import Image, ImageEnhance, ImageOps
+
+
+# Minimum value for posterize (0 in EfficientNet implementation)
+POSTERIZE_MIN = 1
+
+# Parameters for affine warping and rotation
+WARP_PARAMS = {"fillcolor": (128, 128, 128), "resample": Image.BILINEAR}
+
+
+def affine_warp(im, data):
+    """Applies affine transform to image."""
+    return im.transform(im.size, Image.AFFINE, data, **WARP_PARAMS)
+
+
+OP_FUNCTIONS = {
+    # Each op takes an image x and a level v and returns an augmented image.
+    "auto_contrast": lambda x, _: ImageOps.autocontrast(x),
+    "equalize": lambda x, _: ImageOps.equalize(x),
+    "invert": lambda x, _: ImageOps.invert(x),
+    "rotate": lambda x, v: x.rotate(v, **WARP_PARAMS),
+    "posterize": lambda x, v: ImageOps.posterize(x, max(POSTERIZE_MIN, int(v))),
+    "posterize_inc": lambda x, v: ImageOps.posterize(x, max(POSTERIZE_MIN, 4 - int(v))),
+    "solarize": lambda x, v: x.point(lambda i: i if i < int(v) else 255 - i),
+    "solarize_inc": lambda x, v: x.point(lambda i: i if i < 256 - v else 255 - i),
+    "solarize_add": lambda x, v: x.point(lambda i: min(255, v + i) if i < 128 else i),
+    "color": lambda x, v: ImageEnhance.Color(x).enhance(v),
+    "contrast": lambda x, v: ImageEnhance.Contrast(x).enhance(v),
+    "brightness": lambda x, v: ImageEnhance.Brightness(x).enhance(v),
+    "sharpness": lambda x, v: ImageEnhance.Sharpness(x).enhance(v),
+    "color_inc": lambda x, v: ImageEnhance.Color(x).enhance(1 + v),
+    "contrast_inc": lambda x, v: ImageEnhance.Contrast(x).enhance(1 + v),
+    "brightness_inc": lambda x, v: ImageEnhance.Brightness(x).enhance(1 + v),
+    "sharpness_inc": lambda x, v: ImageEnhance.Sharpness(x).enhance(1 + v),
+    "shear_x": lambda x, v: affine_warp(x, (1, v, 0, 0, 1, 0)),
+    "shear_y": lambda x, v: affine_warp(x, (1, 0, 0, v, 1, 0)),
+    "trans_x": lambda x, v: affine_warp(x, (1, 0, v * x.size[0], 0, 1, 0)),
+    "trans_y": lambda x, v: affine_warp(x, (1, 0, 0, 0, 1, v * x.size[1])),
+}
+
+
+OP_RANGES = {
+    # Ranges for each op in the form of a (min, max, negate).
+    "auto_contrast": (0, 1, False),
+    "equalize": (0, 1, False),
+    "invert": (0, 1, False),
+    "rotate": (0.0, 30.0, True),
+    "posterize": (0, 4, False),
+    "posterize_inc": (0, 4, False),
+    "solarize": (0, 256, False),
+    "solarize_inc": (0, 256, False),
+    "solarize_add": (0, 110, False),
+    "color": (0.1, 1.9, False),
+    "contrast": (0.1, 1.9, False),
+    "brightness": (0.1, 1.9, False),
+    "sharpness": (0.1, 1.9, False),
+    "color_inc": (0, 0.9, True),
+    "contrast_inc": (0, 0.9, True),
+    "brightness_inc": (0, 0.9, True),
+    "sharpness_inc": (0, 0.9, True),
+    "shear_x": (0.0, 0.3, True),
+    "shear_y": (0.0, 0.3, True),
+    "trans_x": (0.0, 0.45, True),
+    "trans_y": (0.0, 0.45, True),
+}
+
+
+AUTOAUG_POLICY = [
+    # AutoAugment "policy_v0" in form of (op, prob, magnitude), where magnitude <= 1.
+    [("equalize", 0.8, 0.1), ("shear_y", 0.8, 0.4)],
+    [("color", 0.4, 0.9), ("equalize", 0.6, 0.3)],
+    [("color", 0.4, 0.1), ("rotate", 0.6, 0.8)],
+    [("solarize", 0.8, 0.3), ("equalize", 0.4, 0.7)],
+    [("solarize", 0.4, 0.2), ("solarize", 0.6, 0.2)],
+    [("color", 0.2, 0.0), ("equalize", 0.8, 0.8)],
+    [("equalize", 0.4, 0.8), ("solarize_add", 0.8, 0.3)],
+    [("shear_x", 0.2, 0.9), ("rotate", 0.6, 0.8)],
+    [("color", 0.6, 0.1), ("equalize", 1.0, 0.2)],
+    [("invert", 0.4, 0.9), ("rotate", 0.6, 0.0)],
+    [("equalize", 1.0, 0.9), ("shear_y", 0.6, 0.3)],
+    [("color", 0.4, 0.7), ("equalize", 0.6, 0.0)],
+    [("posterize", 0.4, 0.6), ("auto_contrast", 0.4, 0.7)],
+    [("solarize", 0.6, 0.8), ("color", 0.6, 0.9)],
+    [("solarize", 0.2, 0.4), ("rotate", 0.8, 0.9)],
+    [("rotate", 1.0, 0.7), ("trans_y", 0.8, 0.9)],
+    [("shear_x", 0.0, 0.0), ("solarize", 0.8, 0.4)],
+    [("shear_y", 0.8, 0.0), ("color", 0.6, 0.4)],
+    [("color", 1.0, 0.0), ("rotate", 0.6, 0.2)],
+    [("equalize", 0.8, 0.4), ("equalize", 0.0, 0.8)],
+    [("equalize", 1.0, 0.4), ("auto_contrast", 0.6, 0.2)],
+    [("shear_y", 0.4, 0.7), ("solarize_add", 0.6, 0.7)],
+    [("posterize", 0.8, 0.2), ("solarize", 0.6, 1.0)],
+    [("solarize", 0.6, 0.8), ("equalize", 0.6, 0.1)],
+    [("color", 0.8, 0.6), ("rotate", 0.4, 0.5)],
+]
+
+
+RANDAUG_OPS = [
+    # RandAugment list of operations using "increasing" transforms.
+    "auto_contrast",
+    "equalize",
+    "invert",
+    "rotate",
+    "posterize_inc",
+    "solarize_inc",
+    "solarize_add",
+    "color_inc",
+    "contrast_inc",
+    "brightness_inc",
+    "sharpness_inc",
+    "shear_x",
+    "shear_y",
+    "trans_x",
+    "trans_y",
+]
+
+
+def apply_op(im, op, prob, magnitude):
+    """Apply the selected op to image with given probability and magnitude."""
+    # The magnitude is converted to an absolute value v for an op (some ops use -v or v)
+    assert 0 <= magnitude <= 1
+    assert op in OP_RANGES and op in OP_FUNCTIONS, "unknown op " + op
+    if prob < 1 and random.random() > prob:
+        return im
+    min_v, max_v, negate = OP_RANGES[op]
+    v = magnitude * (max_v - min_v) + min_v
+    v = -v if negate and random.random() > 0.5 else v
+    return OP_FUNCTIONS[op](im, v)
+
+
+def rand_augment(im, magnitude, ops=None, n_ops=2, prob=1.0):
+    """Applies random augmentation to an image."""
+    ops = ops if ops else RANDAUG_OPS
+    for op in np.random.choice(ops, int(n_ops)):
+        im = apply_op(im, op, prob, magnitude)
+    return im
+
+
+def auto_augment(im, policy=None):
+    """Apply auto augmentation to an image."""
+    policy = policy if policy else AUTOAUG_POLICY
+    for op, prob, magnitude in random.choice(policy):
+        im = apply_op(im, op, prob, magnitude)
+    return im
+
+
+def make_augment(augment_str):
+    """Generate augmentation function from separated parameter string.
+    The parameter string augment_str may be either "AutoAugment" or "RandAugment".
+    Undocumented use allows for specifying extra params, e.g. "RandAugment_N2_M0.5"."""
+    params = augment_str.split("_")
+    names = {"N": "n_ops", "M": "magnitude", "P": "prob"}
+    assert params[0] in ["RandAugment", "AutoAugment"]
+    assert all(p[0] in names for p in params[1:])
+    keys = [names[p[0]] for p in params[1:]]
+    vals = [float(p[1:]) for p in params[1:]]
+    augment = rand_augment if params[0] == "RandAugment" else auto_augment
+    return lambda im: augment(im, **dict(zip(keys, vals)))
+
+
+def visualize_ops(im, ops=None, num_steps=10):
+    """Visualize ops by applying each op by varying amounts."""
+    ops = ops if ops else RANDAUG_OPS
+    w, h, magnitudes = im.size[0], im.size[1], np.linspace(0, 1, num_steps)
+    output = Image.new("RGB", (w * num_steps, h * len(ops)))
+    for i, op in enumerate(ops):
+        for j, m in enumerate(magnitudes):
+            out = apply_op(im, op, prob=1.0, magnitude=m)
+            output.paste(out, (j * w, i * h))
+    return output
+
+
+def visualize_aug(im, augment=rand_augment, num_trials=10, **kwargs):
+    """Visualize augmentation by applying random augmentations."""
+    w, h = im.size[0], im.size[1]
+    output = Image.new("RGB", (w * num_trials, h * num_trials))
+    for i in range(num_trials):
+        for j in range(num_trials):
+            output.paste(augment(im, **kwargs), (j * w, i * h))
+    return output

--- a/pycls/datasets/transforms.py
+++ b/pycls/datasets/transforms.py
@@ -5,104 +5,76 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-"""Image transformations."""
+"""Image transformations on HWC float images with RGB channel order."""
 
-import math
+from math import ceil, sqrt
 
 import cv2
 import numpy as np
+from PIL import Image
+from pycls.datasets.augment import make_augment
 
 
-def color_norm(im, mean, std):
-    """Performs per-channel normalization (CHW format)."""
-    for i in range(im.shape[0]):
-        im[i] = im[i] - mean[i]
-        im[i] = im[i] / std[i]
-    return im
-
-
-def zero_pad(im, pad_size):
-    """Performs zero padding (CHW format)."""
-    pad_width = ((0, 0), (pad_size, pad_size), (pad_size, pad_size))
-    return np.pad(im, pad_width, mode="constant")
-
-
-def horizontal_flip(im, p, order="CHW"):
-    """Performs horizontal flip (CHW or HWC format)."""
-    assert order in ["CHW", "HWC"]
-    if np.random.uniform() < p:
-        if order == "CHW":
-            im = im[:, :, ::-1]
-        else:
-            im = im[:, ::-1, :]
-    return im
-
-
-def random_crop(im, size, pad_size=0):
-    """Performs random crop (CHW format)."""
-    if pad_size > 0:
-        im = zero_pad(im=im, pad_size=pad_size)
-    h, w = im.shape[1:]
-    y = np.random.randint(0, h - size)
-    x = np.random.randint(0, w - size)
-    im_crop = im[:, y : (y + size), x : (x + size)]
-    assert im_crop.shape[1:] == (size, size)
-    return im_crop
-
-
-def scale(size, im):
-    """Performs scaling (HWC format)."""
+def scale_and_center_crop(im, scale_size, crop_size):
+    """Performs scaling and center cropping (used for testing)."""
     h, w = im.shape[:2]
-    if (w <= h and w == size) or (h <= w and h == size):
-        return im
-    h_new, w_new = size, size
-    if w < h:
-        h_new = int(math.floor((float(h) / w) * size))
-    else:
-        w_new = int(math.floor((float(w) / h) * size))
-    im = cv2.resize(im, (w_new, h_new), interpolation=cv2.INTER_LINEAR)
-    return im.astype(np.float32)
-
-
-def center_crop(size, im):
-    """Performs center cropping (HWC format)."""
-    h, w = im.shape[:2]
-    y = int(math.ceil((h - size) / 2))
-    x = int(math.ceil((w - size) / 2))
-    im_crop = im[y : (y + size), x : (x + size), :]
-    assert im_crop.shape[:2] == (size, size)
-    return im_crop
+    if w < h and w != scale_size:
+        w, h = scale_size, int(h / w * scale_size)
+        im = cv2.resize(im, (w, h), interpolation=cv2.INTER_LINEAR)
+    elif h <= w and h != scale_size:
+        w, h = int(w / h * scale_size), scale_size
+        im = cv2.resize(im, (w, h), interpolation=cv2.INTER_LINEAR)
+    x = ceil((w - crop_size) / 2)
+    y = ceil((h - crop_size) / 2)
+    return im[y : (y + crop_size), x : (x + crop_size), :]
 
 
 def random_sized_crop(im, size, area_frac=0.08, max_iter=10):
-    """Performs Inception-style cropping (HWC format)."""
+    """Performs Inception-style cropping (used for training)."""
     h, w = im.shape[:2]
     area = h * w
     for _ in range(max_iter):
         target_area = np.random.uniform(area_frac, 1.0) * area
         aspect_ratio = np.random.uniform(3.0 / 4.0, 4.0 / 3.0)
-        w_crop = int(round(math.sqrt(float(target_area) * aspect_ratio)))
-        h_crop = int(round(math.sqrt(float(target_area) / aspect_ratio)))
+        w_crop = round(sqrt(target_area * aspect_ratio))
+        h_crop = round(sqrt(target_area / aspect_ratio))
         if np.random.uniform() < 0.5:
             w_crop, h_crop = h_crop, w_crop
         if h_crop <= h and w_crop <= w:
             y = 0 if h_crop == h else np.random.randint(0, h - h_crop)
             x = 0 if w_crop == w else np.random.randint(0, w - w_crop)
-            im_crop = im[y : (y + h_crop), x : (x + w_crop), :]
-            assert im_crop.shape[:2] == (h_crop, w_crop)
-            im_crop = cv2.resize(im_crop, (size, size), interpolation=cv2.INTER_LINEAR)
-            return im_crop.astype(np.float32)
-    return center_crop(size, scale(size, im))
+            im = im[y : (y + h_crop), x : (x + w_crop), :]
+            return cv2.resize(im, (size, size), interpolation=cv2.INTER_LINEAR)
+    return scale_and_center_crop(im, size, size)
+
+
+def horizontal_flip(im, prob=0.5):
+    """Performs horizontal flip (used for training)."""
+    return im[:, ::-1, :] if np.random.uniform() < prob else im
+
+
+def augment(im, augment_str):
+    """Augments image (used for training)."""
+    if augment_str:
+        im = Image.fromarray((im * 255).astype(np.uint8))
+        im = make_augment(augment_str)(im)
+        im = np.asarray(im).astype(np.float32) / 255
+    return im
 
 
 def lighting(im, alpha_std, eig_val, eig_vec):
-    """Performs AlexNet-style PCA jitter (CHW format)."""
-    if alpha_std == 0:
-        return im
+    """Performs AlexNet-style PCA jitter (used for training)."""
     alpha = np.random.normal(0, alpha_std, size=(1, 3))
     alpha = np.repeat(alpha, 3, axis=0)
-    eig_val = np.repeat(eig_val, 3, axis=0)
-    rgb = np.sum(eig_vec * alpha * eig_val, axis=1)
-    for i in range(im.shape[0]):
-        im[i] = im[i] + rgb[2 - i]
+    eig_val = np.repeat(np.array(eig_val), 3, axis=0)
+    rgb = np.sum(np.array(eig_vec) * alpha * eig_val, axis=1)
+    for i in range(3):
+        im[:, :, i] = im[:, :, i] + rgb[i]
+    return im
+
+
+def color_norm(im, mean, std):
+    """Performs per-channel normalization (used for training and testing)."""
+    for i in range(3):
+        im[:, :, i] = (im[:, :, i] - mean[i]) / std[i]
     return im


### PR DESCRIPTION
High-level comments:
 -fully backward compatible changes (+)
 -code cleanup and simplifications (+)
 -adds autoaugment and randaug (+)
 -for backward comp. still use opencv loader and image resize (+/-)
 -still provides custom implementations of transforms (+/-)

Notes:
 -augment.py: contains clean implementation of autoaug and randaug
 -augment.py: also contains visualization utilities for augmentations
 -cifar.py: no longer depends on transforms.py (simplifies transforms)
 -cifar.py: has its own very simple inlined transforms in _prepare_im
 -config.py: exposes options for controlling aug and pca jitter
 -transforms.py: now all operate on HWC float images in RBG order, yay
 -transforms.py: a lot of standardization / simplification
 -transforms.py: adds wrapper for augmentation policies
 -imagenet.py: simplified, can use autoaugment, can control pca aug