### PR TITLE
train enhancements: smooth labels, mixup, mixed precision

### DIFF
--- a/pycls/core/builders.py
+++ b/pycls/core/builders.py
@@ -7,8 +7,8 @@
 
 """Model and loss construction functions."""
 
-import torch
 from pycls.core.config import cfg
+from pycls.core.net import SoftCrossEntropyLoss
 from pycls.models.anynet import AnyNet
 from pycls.models.effnet import EffNet
 from pycls.models.regnet import RegNet
@@ -19,7 +19,7 @@ from pycls.models.resnet import ResNet
 _models = {"anynet": AnyNet, "effnet": EffNet, "resnet": ResNet, "regnet": RegNet}
 
 # Supported loss functions
-_loss_funs = {"cross_entropy": torch.nn.CrossEntropyLoss}
+_loss_funs = {"cross_entropy": SoftCrossEntropyLoss}
 
 
 def get_model():

--- a/pycls/core/config.py
+++ b/pycls/core/config.py
@@ -242,6 +242,15 @@ _C.TRAIN.AUTO_RESUME = True
 # Weights to start training from
 _C.TRAIN.WEIGHTS = ""
 
+# If True train using mixed precision
+_C.TRAIN.MIXED_PRECISION = False
+
+# Label smoothing value in 0 to 1 where (0 gives no smoothing)
+_C.TRAIN.LABEL_SMOOTHING = 0.0
+
+# Batch mixup regularization value in 0 to 1 (0 gives no mixup)
+_C.TRAIN.MIXUP_ALPHA = 0.0
+
 # Standard deviation for AlexNet-style PCA jitter (0 gives no PCA jitter)
 _C.TRAIN.PCA_STD = 0.1
 

--- a/pycls/core/net.py
+++ b/pycls/core/net.py
@@ -9,6 +9,7 @@
 
 import itertools
 
+import numpy as np
 import pycls.core.distributed as dist
 import torch
 from pycls.core.config import cfg
@@ -58,3 +59,40 @@ def complexity(model):
     cx = {"h": size, "w": size, "flops": 0, "params": 0, "acts": 0}
     cx = unwrap_model(model).complexity(cx)
     return {"flops": cx["flops"], "params": cx["params"], "acts": cx["acts"]}
+
+
+def smooth_one_hot_labels(labels):
+    """Convert each label to a one-hot vector."""
+    n_classes, label_smooth = cfg.MODEL.NUM_CLASSES, cfg.TRAIN.LABEL_SMOOTHING
+    err_str = "Invalid input to one_hot_vector()"
+    assert labels.ndim == 1 and labels.max() < n_classes, err_str
+    shape = (labels.shape[0], n_classes)
+    neg_val = label_smooth / n_classes
+    pos_val = 1.0 - label_smooth + neg_val
+    labels_one_hot = torch.full(shape, neg_val, dtype=torch.float, device=labels.device)
+    labels_one_hot.scatter_(1, labels.long().view(-1, 1), pos_val)
+    return labels_one_hot
+
+
+class SoftCrossEntropyLoss(torch.nn.Module):
+    """SoftCrossEntropyLoss (useful for label smoothing and mixup).
+    Identical to torch.nn.CrossEntropyLoss if used with one-hot labels."""
+
+    def __init__(self):
+        super(SoftCrossEntropyLoss, self).__init__()
+
+    def forward(self, x, y):
+        loss = -y * torch.nn.functional.log_softmax(x, -1)
+        return torch.sum(loss) / x.shape[0]
+
+
+def mixup(inputs, labels):
+    """Apply mixup to minibatch (https://arxiv.org/abs/1710.09412)."""
+    alpha = cfg.TRAIN.MIXUP_ALPHA
+    assert labels.shape[1] == cfg.MODEL.NUM_CLASSES, "mixup labels must be one-hot"
+    if alpha > 0:
+        m = np.random.beta(alpha, alpha)
+        permutation = torch.randperm(labels.shape[0])
+        inputs = m * inputs + (1.0 - m) * inputs[permutation, :]
+        labels = m * labels + (1.0 - m) * labels[permutation, :]
+    return inputs, labels, labels.argmax(1)


### PR DESCRIPTION
notes:
-benchmark.py: properly time w mixed precision and smooth labels
-builders.py: default loss is now SoftCrossEntropyLoss
-config.py: options for MIXED_PRECISION, LABEL_SMOOTHING, MIXUP_ALPHA
-net.py: added smooth_one_hot_labels, mixup, SoftCrossEntropyLoss
-trainer.py: uses smooth labels, mixup, mixed precision