### PR TITLE
Add deterministic for reproduce the experiment

### DIFF
--- a/pycls/core/config.py
+++ b/pycls/core/config.py
@@ -291,6 +291,7 @@ _C.CUDNN = CfgNode()
 
 # Perform benchmarking to select fastest CUDNN algorithms (best for fixed input sizes)
 _C.CUDNN.BENCHMARK = True
+_C.CUDNN.DETERMINISTIC = False
 
 
 # ------------------------------- Precise time options ------------------------------- #

--- a/pycls/core/env.py
+++ b/pycls/core/env.py
@@ -33,3 +33,5 @@ def setup_env():
     random.seed(cfg.RNG_SEED)
     # Configure the CUDNN backend
     torch.backends.cudnn.benchmark = cfg.CUDNN.BENCHMARK
+    # Configure the convolution determinism
+    torch.backends.cudnn.deterministic = cfg.DETERMINISTIC


### PR DESCRIPTION
add ``torch.backends.cudnn.deterministic`` cfg for  reproduce the experiments

Default(for the best training speed): 

- _C.CUDNN.BENCHMARK = True
- _C.CUDNN.DETERMINISTIC = False

Reproduce the experiment(for ablation experiment or hyperparameter tuning): 

- _C.CUDNN.BENCHMARK = False
- _C.CUDNN.DETERMINISTIC = True

```python
# Configure the CUDNN backend
torch.backends.cudnn.benchmark = cfg.CUDNN.BENCHMARK
# Configure the convolution determinism
torch.backends.cudnn.deterministic = cfg.DETERMINISTIC

```
