### PR TITLE
minor cleanup after io migration to PathManager

### DIFF
--- a/dev/model_zoo_tables.py
+++ b/dev/model_zoo_tables.py
@@ -13,7 +13,7 @@ import os
 import pycls.core.builders as builders
 import pycls.core.net as net
 import pycls.models.model_zoo as model_zoo
-from pycls.core.config import cfg, reset_cfg
+from pycls.core.config import cfg, load_cfg, reset_cfg
 
 
 # Location of pycls directory
@@ -47,7 +47,7 @@ def get_model_data(name, timings, errors):
     """Get model data for a single model."""
     # Load model config
     reset_cfg()
-    cfg.merge_from_file(model_zoo.get_config_file(name))
+    load_cfg(model_zoo.get_config_file(name))
     config_url, _, model_id, _, weight_url_full = model_zoo.get_model_info(name)
     # Get model complexity
     cx = net.complexity(builders.get_model())

--- a/pycls/core/checkpoint.py
+++ b/pycls/core/checkpoint.py
@@ -8,12 +8,11 @@
 """Functions that handle saving and loading of checkpoints."""
 
 import os
-from shutil import copyfileobj
 
 import pycls.core.distributed as dist
 import torch
-from iopath.common.file_io import g_pathmgr
 from pycls.core.config import cfg
+from pycls.core.io import pathmgr
 from pycls.core.net import unwrap_model
 
 
@@ -43,7 +42,7 @@ def get_checkpoint_best():
 def get_last_checkpoint():
     """Retrieves the most recent checkpoint (highest epoch number)."""
     checkpoint_dir = get_checkpoint_dir()
-    checkpoints = [f for f in g_pathmgr.ls(checkpoint_dir) if _NAME_PREFIX in f]
+    checkpoints = [f for f in pathmgr.ls(checkpoint_dir) if _NAME_PREFIX in f]
     last_checkpoint_name = sorted(checkpoints)[-1]
     return os.path.join(checkpoint_dir, last_checkpoint_name)
 
@@ -51,9 +50,9 @@ def get_last_checkpoint():
 def has_checkpoint():
     """Determines if there are checkpoints available."""
     checkpoint_dir = get_checkpoint_dir()
-    if not g_pathmgr.exists(checkpoint_dir):
+    if not pathmgr.exists(checkpoint_dir):
         return False
-    return any(_NAME_PREFIX in f for f in g_pathmgr.ls(checkpoint_dir))
+    return any(_NAME_PREFIX in f for f in pathmgr.ls(checkpoint_dir))
 
 
 def save_checkpoint(model, optimizer, epoch, best):
@@ -62,7 +61,7 @@ def save_checkpoint(model, optimizer, epoch, best):
     if not dist.is_master_proc():
         return
     # Ensure that the checkpoint dir exists
-    g_pathmgr.mkdirs(get_checkpoint_dir())
+    pathmgr.mkdirs(get_checkpoint_dir())
     # Record the state
     checkpoint = {
         "epoch": epoch,
@@ -72,21 +71,19 @@ def save_checkpoint(model, optimizer, epoch, best):
     }
     # Write the checkpoint
     checkpoint_file = get_checkpoint(epoch + 1)
-    with g_pathmgr.open(checkpoint_file, "wb") as f:
+    with pathmgr.open(checkpoint_file, "wb") as f:
         torch.save(checkpoint, f)
     # If best copy checkpoint to the best checkpoint
     if best:
-        with g_pathmgr.open(checkpoint_file, "rb") as src:
-            with g_pathmgr.open(get_checkpoint_best(), "wb") as dst:
-                copyfileobj(src, dst)
+        pathmgr.copy(checkpoint_file, get_checkpoint_best())
     return checkpoint_file
 
 
 def load_checkpoint(checkpoint_file, model, optimizer=None):
     """Loads the checkpoint from the given file."""
     err_str = "Checkpoint '{}' not found"
-    assert g_pathmgr.exists(checkpoint_file), err_str.format(checkpoint_file)
-    with g_pathmgr.open(checkpoint_file, "rb") as f:
+    assert pathmgr.exists(checkpoint_file), err_str.format(checkpoint_file)
+    with pathmgr.open(checkpoint_file, "rb") as f:
         checkpoint = torch.load(f, map_location="cpu")
     unwrap_model(model).load_state_dict(checkpoint["model_state"])
     optimizer.load_state_dict(checkpoint["optimizer_state"]) if optimizer else ()
@@ -97,12 +94,10 @@ def delete_checkpoints(checkpoint_dir=None, keep="all"):
     """Deletes unneeded checkpoints, keep can be "all", "last", or "none"."""
     assert keep in ["all", "last", "none"], "Invalid keep setting: {}".format(keep)
     checkpoint_dir = checkpoint_dir if checkpoint_dir else get_checkpoint_dir()
-    if keep == "all" or not g_pathmgr.exists(checkpoint_dir):
+    if keep == "all" or not pathmgr.exists(checkpoint_dir):
         return 0
-    checkpoints = [f for f in g_pathmgr.ls(checkpoint_dir) if _NAME_PREFIX in f]
+    checkpoints = [f for f in pathmgr.ls(checkpoint_dir) if _NAME_PREFIX in f]
     checkpoints = sorted(checkpoints)[:-1] if keep == "last" else checkpoints
-    [
-        g_pathmgr.rm(os.path.join(checkpoint_dir, checkpoint))
-        for checkpoint in checkpoints
-    ]
+    for checkpoint in checkpoints:
+        pathmgr.rm(os.path.join(checkpoint_dir, checkpoint))
     return len(checkpoints)

--- a/pycls/core/config.py
+++ b/pycls/core/config.py
@@ -11,8 +11,7 @@ import argparse
 import os
 import sys
 
-from iopath.common.file_io import g_pathmgr
-from pycls.core.io import cache_url
+from pycls.core.io import cache_url, pathmgr
 from yacs.config import CfgNode as CfgNode
 
 
@@ -378,28 +377,22 @@ def cache_cfg_urls():
     _C.TEST.WEIGHTS = cache_url(_C.TEST.WEIGHTS, _C.DOWNLOAD_CACHE)
 
 
-def merge_from_file(cfg_file):
-    with g_pathmgr.open(cfg_file, "r") as f:
-        cfg = _C.load_cfg(f)
-    _C.merge_from_other_cfg(cfg)
-
-
 def dump_cfg():
     """Dumps the config to the output directory."""
     cfg_file = os.path.join(_C.OUT_DIR, _C.CFG_DEST)
-    with g_pathmgr.open(cfg_file, "w") as f:
+    with pathmgr.open(cfg_file, "w") as f:
         _C.dump(stream=f)
 
 
-def load_cfg(out_dir, cfg_dest="config.yaml"):
-    """Loads config from specified output directory."""
-    cfg_file = os.path.join(out_dir, cfg_dest)
-    merge_from_file(cfg_file)
+def load_cfg(cfg_file):
+    """Loads config from specified file."""
+    with pathmgr.open(cfg_file, "r") as f:
+        _C.merge_from_other_cfg(_C.load_cfg(f))
 
 
 def reset_cfg():
     """Reset config to initial state."""
-    cfg.merge_from_other_cfg(_CFG_DEFAULT)
+    _C.merge_from_other_cfg(_CFG_DEFAULT)
 
 
 def load_cfg_fom_args(description="Config file options."):
@@ -413,5 +406,5 @@ def load_cfg_fom_args(description="Config file options."):
         parser.print_help()
         sys.exit(1)
     args = parser.parse_args()
-    merge_from_file(args.cfg_file)
+    load_cfg(args.cfg_file)
     _C.merge_from_list(args.opts)

--- a/pycls/core/env.py
+++ b/pycls/core/env.py
@@ -1,35 +1,8 @@
-import random
+#!/usr/bin/env python3
 
-import numpy as np
-import pycls.core.config as config
-import pycls.core.distributed as dist
-import pycls.core.logging as logging
-import torch
-from iopath.common.file_io import g_pathmgr
-from pycls.core.config import cfg
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
-
-logger = logging.get_logger(__name__)
-
-
-def setup_env():
-    """Sets up environment for training or testing."""
-    if dist.is_master_proc():
-        # Ensure that the output dir exists
-        g_pathmgr.mkdirs(cfg.OUT_DIR)
-        # Save the config
-        config.dump_cfg()
-    # Setup logging
-    logging.setup_logging()
-    # Log torch, cuda, and cudnn versions
-    version = [torch.__version__, torch.version.cuda, torch.backends.cudnn.version()]
-    logger.info("PyTorch Version: torch={}, cuda={}, cudnn={}".format(*version))
-    # Log the config as both human readable and as a json
-    logger.info("Config:\n{}".format(cfg)) if cfg.VERBOSE else ()
-    logger.info(logging.dump_log_data(cfg, "cfg", None))
-    # Fix the RNG seeds (see RNG comment in core/config.py for discussion)
-    np.random.seed(cfg.RNG_SEED)
-    torch.manual_seed(cfg.RNG_SEED)
-    random.seed(cfg.RNG_SEED)
-    # Configure the CUDNN backend
-    torch.backends.cudnn.benchmark = cfg.CUDNN.BENCHMARK
+"""This file is obsolete and will be removed in a future commit."""

--- a/pycls/core/io.py
+++ b/pycls/core/io.py
@@ -13,8 +13,11 @@ import re
 import sys
 from urllib import request as urlrequest
 
-from iopath.common.file_io import g_pathmgr
+from iopath.common.file_io import PathManagerFactory
 
+
+# instantiate global path manager for pycls
+pathmgr = PathManagerFactory.get()
 
 logger = logging.getLogger(__name__)
 
@@ -31,11 +34,11 @@ def cache_url(url_or_file, cache_dir, base_url=_PYCLS_BASE_URL):
     url = url_or_file
     assert url.startswith(base_url), "url must start with: {}".format(base_url)
     cache_file_path = url.replace(base_url, cache_dir)
-    if g_pathmgr.exists(cache_file_path):
+    if pathmgr.exists(cache_file_path):
         return cache_file_path
     cache_file_dir = os.path.dirname(cache_file_path)
-    if not g_pathmgr.exists(cache_file_dir):
-        g_pathmgr.mkdirs(cache_file_dir)
+    if not pathmgr.exists(cache_file_dir):
+        pathmgr.mkdirs(cache_file_dir)
     logger.info("Downloading remote file {} to {}".format(url, cache_file_path))
     download_url(url, cache_file_path)
     return cache_file_path
@@ -66,7 +69,7 @@ def download_url(url, dst_file_path, chunk_size=8192, progress_hook=_progress_ba
     total_size = response.info().get("Content-Length").strip()
     total_size = int(total_size)
     bytes_so_far = 0
-    with g_pathmgr.open(dst_file_path, "wb") as f:
+    with pathmgr.open(dst_file_path, "wb") as f:
         while 1:
             chunk = response.read(chunk_size)
             bytes_so_far += len(chunk)

--- a/pycls/core/logging.py
+++ b/pycls/core/logging.py
@@ -15,8 +15,8 @@ import sys
 
 import pycls.core.distributed as dist
 import simplejson
-from iopath.common.file_io import g_pathmgr
 from pycls.core.config import cfg
+from pycls.core.io import pathmgr
 
 
 # Show filename and line number in logs
@@ -86,9 +86,9 @@ def float_to_decimal(data, prec=4):
 
 def get_log_files(log_dir, name_filter="", log_file=_LOG_FILE):
     """Get all log files in directory containing subdirs of trained models."""
-    names = [n for n in sorted(g_pathmgr.ls(log_dir)) if name_filter in n]
+    names = [n for n in sorted(pathmgr.ls(log_dir)) if name_filter in n]
     files = [os.path.join(log_dir, n, log_file) for n in names]
-    f_n_ps = [(f, n) for (f, n) in zip(files, names) if g_pathmgr.exists(f)]
+    f_n_ps = [(f, n) for (f, n) in zip(files, names) if pathmgr.exists(f)]
     files, names = zip(*f_n_ps) if f_n_ps else ([], [])
     return files, names
 
@@ -96,8 +96,8 @@ def get_log_files(log_dir, name_filter="", log_file=_LOG_FILE):
 def load_log_data(log_file, data_types_to_skip=()):
     """Loads log data into a dictionary of the form data[data_type][metric][index]."""
     # Load log_file
-    assert g_pathmgr.exists(log_file), "Log file not found: {}".format(log_file)
-    with g_pathmgr.open(log_file, "r") as f:
+    assert pathmgr.exists(log_file), "Log file not found: {}".format(log_file)
+    with pathmgr.open(log_file, "r") as f:
         lines = f.readlines()
     # Extract and parse lines that start with _TAG and have a type specified
     lines = [l[l.find(_TAG) + len(_TAG) :] for l in lines if _TAG in l]

--- a/pycls/datasets/cifar10.py
+++ b/pycls/datasets/cifar10.py
@@ -13,8 +13,8 @@ import pickle
 import numpy as np
 import pycls.core.logging as logging
 import torch.utils.data
-from iopath.common.file_io import g_pathmgr
 from pycls.core.config import cfg
+from pycls.core.io import pathmgr
 
 
 logger = logging.get_logger(__name__)
@@ -28,11 +28,10 @@ class Cifar10(torch.utils.data.Dataset):
     """CIFAR-10 dataset."""
 
     def __init__(self, data_path, split):
-        assert g_pathmgr.exists(data_path), "Data path '{}' not found".format(data_path)
+        assert pathmgr.exists(data_path), "Data path '{}' not found".format(data_path)
         splits = ["train", "test"]
         assert split in splits, "Split '{}' not supported for cifar".format(split)
         logger.info("Constructing CIFAR-10 {}...".format(split))
-        self._im_size = cfg.TRAIN.IM_SIZE
         self._data_path, self._split = data_path, split
         self._inputs, self._labels = self._load_data()
 
@@ -48,13 +47,14 @@ class Cifar10(torch.utils.data.Dataset):
         inputs, labels = [], []
         for batch_name in batch_names:
             batch_path = os.path.join(self._data_path, batch_name)
-            with g_pathmgr.open(batch_path, "rb") as f:
+            with pathmgr.open(batch_path, "rb") as f:
                 data = pickle.load(f, encoding="bytes")
             inputs.append(data[b"data"])
             labels += data[b"labels"]
         # Combine and reshape the inputs
+        assert cfg.TRAIN.IM_SIZE == 32, "CIFAR-10 images are 32x32"
         inputs = np.vstack(inputs).astype(np.float32)
-        inputs = inputs.reshape((-1, 3, self._im_size, self._im_size))
+        inputs = inputs.reshape((-1, 3, cfg.TRAIN.IM_SIZE, cfg.TRAIN.IM_SIZE))
         return inputs, labels
 
     def _prepare_im(self, im):
@@ -64,7 +64,7 @@ class Cifar10(torch.utils.data.Dataset):
             im[i] = (im[i] - _MEAN[i]) / _STD[i]
         if self._split == "train":
             # Randomly flip and crop center patch from CHW image
-            size = self._im_size
+            size = cfg.TRAIN.IM_SIZE
             im = im[:, :, ::-1] if np.random.uniform() < 0.5 else im
             im = np.pad(im, ((0, 0), (4, 4), (4, 4)), mode="constant")
             y = np.random.randint(0, im.shape[1] - size)

--- a/pycls/models/model_zoo.py
+++ b/pycls/models/model_zoo.py
@@ -11,7 +11,7 @@ import os
 
 import pycls.core.builders as builders
 import pycls.core.checkpoint as cp
-from pycls.core.config import cfg, reset_cfg
+from pycls.core.config import cfg, load_cfg, reset_cfg
 from pycls.core.io import cache_url
 
 
@@ -141,7 +141,7 @@ def build_model(name, pretrained=False, cfg_list=()):
     # Load the config
     reset_cfg()
     config_file = get_config_file(name)
-    cfg.merge_from_file(config_file)
+    load_cfg(config_file)
     cfg.merge_from_list(cfg_list)
     # Construct model
     model = builders.build_model()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 black==19.3b0
 isort==4.3.21
-fvcore
+iopath
 flake8
 matplotlib
 numpy


### PR DESCRIPTION
best to view this commit using a diff from ca89a79 from 11/20/20
this diff looks big on its own, but it's MINIMAL versus ca89a79
this diff undos some of the orthogonal changes in previous few diffs

-no longer using global path manager (which was deprecated)
-cfg.merge_from_file replaced by load_cfg (old load_cfg unused)
-correct / minimal requirement in requirements.txt
-setup_env() moved back into trainer.py (should not be used elsewhere)
-removed orthogonal changes to cifar10.py introduced in a prev commits