### PR TITLE
fix(models): fix a bug of recursive import

### DIFF
--- a/pycls/models/__init__.py
+++ b/pycls/models/__init__.py
@@ -4,7 +4,3 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-
-"""Expose model zoo constructors."""
-
-from pycls.models.model_zoo import effnet, regnetx, regnety, resnet, resnext


### PR DESCRIPTION
fix a bug caused by __init__.py in  pycls.models.

You could try:
```
import pycls.core.builders as builders
```
to reproduce.