### PR TITLE
Add VitConv configs; use batch-first implementation

### DIFF
--- a/pycls/models/blocks.py
+++ b/pycls/models/blocks.py
@@ -181,7 +181,7 @@ class MultiheadAttention(Module):
 
     def __init__(self, hidden_d, n_heads):
         super(MultiheadAttention, self).__init__()
-        self.block = nn.MultiheadAttention(hidden_d, n_heads)
+        self.block = nn.MultiheadAttention(hidden_d, n_heads, batch_first=True)
 
     def forward(self, query, key, value, need_weights=False):
         return self.block(query=query, key=key, value=value, need_weights=need_weights)


### PR DESCRIPTION
Summary:
The update modifies length-first implementation of
MultiheadAttention to batch-first implementation.
Baseline configs of ViTConv models are added.
PyTorch >= 1.9 required.