### PR TITLE
Using force_alphabetical_sort_within_sections to disable case sensitive sort order within sections

### DIFF
--- a/dev/.isort.cfg
+++ b/dev/.isort.cfg
@@ -7,3 +7,6 @@ default_section = THIRDPARTY
 lines_after_imports = 2
 combine_as_imports = True
 skip=pycls/datasets/data
+# Using force_alphabetical_sort_within_sections to match other Meta codebase
+# convention.
+force_alphabetical_sort_within_sections = True


### PR DESCRIPTION
Differential Revision: D35629371

